### PR TITLE
Add description to `config list-profiles`

### DIFF
--- a/internal/commands/config/list_profiles_internal.go
+++ b/internal/commands/config/list_profiles_internal.go
@@ -1,6 +1,9 @@
 package config_internal
 
 import (
+	"slices"
+
+	"github.com/fatih/color"
 	"github.com/pingidentity/pingcli/internal/output"
 	"github.com/pingidentity/pingcli/internal/profiles"
 )
@@ -10,12 +13,26 @@ func RunInternalConfigListProfiles() {
 	activeProfile := profiles.GetMainConfig().ActiveProfile().Name()
 
 	listStr := "Profiles:\n"
+
+	slices.Sort(profileNames)
+
+	output.SetColorize()
+
+	activeFmt := color.New(color.Bold, color.FgGreen).SprintFunc()
+
 	for _, profileName := range profileNames {
 		if profileName == activeProfile {
-			listStr += "- " + profileName + " (active)\n"
+			listStr += "- " + profileName + activeFmt(" (active)") + " \n"
 		} else {
 			listStr += "- " + profileName + "\n"
 		}
+
+		description, err := profiles.GetMainConfig().ProfileViperValue(profileName, "description")
+		if err != nil {
+			continue
+		}
+
+		listStr += "    " + description + "\n"
 	}
 
 	output.Print(output.Opts{

--- a/internal/commands/config/list_profiles_internal.go
+++ b/internal/commands/config/list_profiles_internal.go
@@ -28,7 +28,7 @@ func RunInternalConfigListProfiles() {
 
 		description, err := profiles.GetMainConfig().ProfileViperValue(profileName, "description")
 		if err != nil {
-			l.Warn().Msgf("Cannot retrieve profile description for profile %s: %s.", profileName, err)
+			l.Warn().Msgf("Cannot retrieve profile description for profile %s: %v", profileName, err)
 			continue
 		}
 

--- a/internal/commands/config/list_profiles_internal.go
+++ b/internal/commands/config/list_profiles_internal.go
@@ -4,11 +4,14 @@ import (
 	"slices"
 
 	"github.com/fatih/color"
+	"github.com/pingidentity/pingcli/internal/logger"
 	"github.com/pingidentity/pingcli/internal/output"
 	"github.com/pingidentity/pingcli/internal/profiles"
 )
 
 func RunInternalConfigListProfiles() {
+	l := logger.Get()
+
 	profileNames := profiles.GetMainConfig().ProfileNames()
 	activeProfile := profiles.GetMainConfig().ActiveProfile().Name()
 
@@ -29,10 +32,13 @@ func RunInternalConfigListProfiles() {
 
 		description, err := profiles.GetMainConfig().ProfileViperValue(profileName, "description")
 		if err != nil {
+			l.Warn().Msgf("Cannot retrieve profile description for profile %s: %s.", profileName, err)
 			continue
 		}
 
-		listStr += "    " + description + "\n"
+		if description != "" {
+			listStr += "    " + description + "\n"
+		}
 	}
 
 	output.Print(output.Opts{

--- a/internal/commands/config/list_profiles_internal.go
+++ b/internal/commands/config/list_profiles_internal.go
@@ -1,8 +1,6 @@
 package config_internal
 
 import (
-	"slices"
-
 	"github.com/fatih/color"
 	"github.com/pingidentity/pingcli/internal/logger"
 	"github.com/pingidentity/pingcli/internal/output"
@@ -17,10 +15,8 @@ func RunInternalConfigListProfiles() {
 
 	listStr := "Profiles:\n"
 
-	slices.Sort(profileNames)
-
+	// We need to enable/disable colorize before applying the color to the string below.
 	output.SetColorize()
-
 	activeFmt := color.New(color.Bold, color.FgGreen).SprintFunc()
 
 	for _, profileName := range profileNames {

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -39,7 +39,7 @@ const (
 	ENUM_RESULT_FAILURE       Result = "Failure"
 )
 
-func Print(output Opts) {
+func SetColorize() {
 	colorizeOutput, err := profiles.GetOptionValue(options.RootColorOption)
 	if err != nil {
 		color.NoColor = false
@@ -51,6 +51,11 @@ func Print(output Opts) {
 			color.NoColor = !colorizeOutputBool
 		}
 	}
+}
+
+func Print(output Opts) {
+
+	SetColorize()
 
 	outputFormat, err := profiles.GetOptionValue(options.RootOutputFormatOption)
 	if err != nil {

--- a/internal/profiles/viper.go
+++ b/internal/profiles/viper.go
@@ -180,6 +180,8 @@ func (m MainConfig) ProfileNames() (profileNames []string) {
 		}
 	}
 
+	slices.Sort(profileNames)
+
 	return profileNames
 }
 

--- a/internal/profiles/viper.go
+++ b/internal/profiles/viper.go
@@ -164,6 +164,7 @@ func (m MainConfig) DeleteProfile(pName string) (err error) {
 }
 
 // Get all profile names from config.yaml configuration file
+// Returns a sorted slice of profile names
 func (m MainConfig) ProfileNames() (profileNames []string) {
 	keySet := make(map[string]struct{})
 	mainViperKeys := m.ViperInstance().AllKeys()


### PR DESCRIPTION
- Sorted the list of profiles alphabetically
- Added a green/bold format for the "(active)" text
- Added each profile description to the output