### PR TITLE
PDI-2080: Homebrew Installation Method

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -65,3 +65,92 @@ release:
   #
   # Default is `keep-existing`.
   mode: append
+
+checksum:
+  # Algorithm to be used.
+  #
+  # Accepted options are:
+  # - sha256
+  # - sha512
+  # - sha1
+  # - crc32
+  # - md5
+  # - sha224
+  # - sha384
+  # - sha3-256
+  # - sha3-512
+  # - sha3-224
+  # - sha3-384
+  # - blake2s
+  # - blake2b
+  #
+  # Default: 'sha256'.
+  algorithm: sha256
+
+  # If true, will create one checksum file for each artifact.
+  split: true
+
+  # Disable the generation/upload of the checksum file.
+  disable: false
+
+brews:
+  -
+    # Git author used to commit to the repository.
+    commit_author:
+      name: goreleaserbot
+      email: bot@goreleaser.com
+
+    # The project name and current git tag are used in the format string.
+    #
+    # Templates: allowed.
+    commit_msg_template: "Brew formula update for {{ .ProjectName }} version {{ .Tag }}"
+
+    # Directory inside the repository to put the formula.
+    directory: Formula
+
+    # Caveats for the user of your binary.
+    # caveats: "How to use this binary"
+
+    # Your app's homepage.
+    #
+    # Default: inferred from global metadata.
+    homepage: "https://github.com/pingidentity/pingcli"
+
+    # Your app's description.
+    #
+    # Templates: allowed.
+    # Default: inferred from global metadata.
+    description: "The Ping CLI is a unified command line interface for configuring and managing Ping Identity Services."
+
+    # SPDX identifier of your app's license.
+    #
+    # Default: inferred from global metadata.
+    license: "Apache License 2.0"
+
+    # Setting this will prevent goreleaser to actually try to commit the updated
+    # formula - instead, the formula file will be stored on the dist directory
+    # only, leaving the responsibility of publishing it to the user.
+    # If set to auto, the release will not be uploaded to the homebrew tap
+    # in case there is an indicator for prerelease in the tag e.g. v1.0.0-rc1
+    #
+    # Templates: allowed.
+    skip_upload: auto
+
+    # So you can `brew test` your formula.
+    #
+    # Template: allowed
+    # test: |
+    #   system "#{bin}/foo --version"
+    #   # ...
+
+    # Repository to push the generated files to.
+    repository:
+      # Repository owner.
+      #
+      # Templates: allowed.
+      owner: pingidentity
+
+      # Repository name.
+      #
+      # Templates: allowed.
+      name: homebrew-tap


### PR DESCRIPTION
- Modify goreleaser to generate formula on release and publish it to pingidentity's homebrew-tap repository.
- Modify goreleaser to generate a checksum file individually for each built binary of pingcli