### PR TITLE
PDI-2121: All secrets should be masked in output

### DIFF
--- a/cmd/config/get_test.go
+++ b/cmd/config/get_test.go
@@ -62,3 +62,34 @@ func TestConfigGetCmd_NoKey(t *testing.T) {
 	err := testutils_cobra.ExecutePingcli(t, "config", "get")
 	testutils.CheckExpectedError(t, err, &expectedErrorPattern)
 }
+
+// https://pkg.go.dev/testing#hdr-Examples
+func Example_getEmptyMaskedValue() {
+	t := testing.T{}
+	_ = testutils_cobra.ExecutePingcli(&t, "config", "get", options.RequestAccessTokenOption.ViperKey)
+
+	// Output:
+	// Configuration values for profile 'default' and key 'request.accessToken':
+	// request.accessToken=
+	// request.accessTokenExpiry=0
+}
+
+// https://pkg.go.dev/testing#hdr-Examples
+func Example_getMaskedValue() {
+	t := testing.T{}
+	_ = testutils_cobra.ExecutePingcli(&t, "config", "get", options.PingFederateClientCredentialsAuthClientSecretOption.ViperKey)
+
+	// Output:
+	// Configuration values for profile 'default' and key 'service.pingfederate.authentication.clientCredentialsAuth.clientSecret':
+	// service.pingfederate.authentication.clientCredentialsAuth.clientSecret=************** (14 character(s))
+}
+
+// https://pkg.go.dev/testing#hdr-Examples
+func Example_getUnmaskedValue() {
+	t := testing.T{}
+	_ = testutils_cobra.ExecutePingcli(&t, "config", "get", options.RootColorOption.ViperKey)
+
+	// Output:
+	// Configuration values for profile 'default' and key 'noColor':
+	// noColor=true
+}

--- a/cmd/config/get_test.go
+++ b/cmd/config/get_test.go
@@ -81,7 +81,7 @@ func Example_getMaskedValue() {
 
 	// Output:
 	// Configuration values for profile 'default' and key 'service.pingfederate.authentication.clientCredentialsAuth.clientSecret':
-	// service.pingfederate.authentication.clientCredentialsAuth.clientSecret=************** (14 character(s))
+	// service.pingfederate.authentication.clientCredentialsAuth.clientSecret=********
 }
 
 // https://pkg.go.dev/testing#hdr-Examples

--- a/cmd/config/set_test.go
+++ b/cmd/config/set_test.go
@@ -91,7 +91,7 @@ func Example_setMaskedValue() {
 
 	// Output:
 	// SUCCESS: Configuration set successfully:
-	// service.pingfederate.authentication.basicAuth.username=******** (8 character(s))
+	// service.pingfederate.authentication.basicAuth.username=********
 }
 
 // https://pkg.go.dev/testing#hdr-Examples

--- a/cmd/config/set_test.go
+++ b/cmd/config/set_test.go
@@ -87,11 +87,11 @@ func TestConfigSetCmd_InvalidFlag(t *testing.T) {
 // https://pkg.go.dev/testing#hdr-Examples
 func Example_setMaskedValue() {
 	t := testing.T{}
-	_ = testutils_cobra.ExecutePingcli(&t, "config", "set", fmt.Sprintf("%s=%s", options.PingFederateBasicAuthUsernameOption.ViperKey, "username"))
+	_ = testutils_cobra.ExecutePingcli(&t, "config", "set", fmt.Sprintf("%s=%s", options.PingFederateBasicAuthPasswordOption.ViperKey, "1234"))
 
 	// Output:
 	// SUCCESS: Configuration set successfully:
-	// service.pingfederate.authentication.basicAuth.username=********
+	// service.pingfederate.authentication.basicAuth.password=********
 }
 
 // https://pkg.go.dev/testing#hdr-Examples

--- a/cmd/config/set_test.go
+++ b/cmd/config/set_test.go
@@ -83,3 +83,23 @@ func TestConfigSetCmd_InvalidFlag(t *testing.T) {
 	err := testutils_cobra.ExecutePingcli(t, "config", "set", "--invalid")
 	testutils.CheckExpectedError(t, err, &expectedErrorPattern)
 }
+
+// https://pkg.go.dev/testing#hdr-Examples
+func Example_setMaskedValue() {
+	t := testing.T{}
+	_ = testutils_cobra.ExecutePingcli(&t, "config", "set", fmt.Sprintf("%s=%s", options.PingFederateBasicAuthUsernameOption.ViperKey, "username"))
+
+	// Output:
+	// SUCCESS: Configuration set successfully:
+	// service.pingfederate.authentication.basicAuth.username=******** (8 character(s))
+}
+
+// https://pkg.go.dev/testing#hdr-Examples
+func Example_setUnmaskedValue() {
+	t := testing.T{}
+	_ = testutils_cobra.ExecutePingcli(&t, "config", "set", fmt.Sprintf("%s=%s", options.RootColorOption.ViperKey, "true"))
+
+	// Output:
+	// SUCCESS: Configuration set successfully:
+	// noColor=true
+}

--- a/cmd/config/unset_test.go
+++ b/cmd/config/unset_test.go
@@ -72,3 +72,23 @@ func TestConfigUnsetCmd_HelpFlag(t *testing.T) {
 	err = testutils_cobra.ExecutePingcli(t, "config", "unset", "-h")
 	testutils.CheckExpectedError(t, err, nil)
 }
+
+// https://pkg.go.dev/testing#hdr-Examples
+func Example_unsetMaskedValue() {
+	t := testing.T{}
+	_ = testutils_cobra.ExecutePingcli(&t, "config", "unset", options.PingFederateBasicAuthUsernameOption.ViperKey)
+
+	// Output:
+	// SUCCESS: Configuration unset successfully:
+	// service.pingfederate.authentication.basicAuth.username=
+}
+
+// https://pkg.go.dev/testing#hdr-Examples
+func Example_unsetUnmaskedValue() {
+	t := testing.T{}
+	_ = testutils_cobra.ExecutePingcli(&t, "config", "unset", options.RootOutputFormatOption.ViperKey)
+
+	// Output:
+	// SUCCESS: Configuration unset successfully:
+	// outputFormat=text
+}

--- a/internal/commands/config/get_internal.go
+++ b/internal/commands/config/get_internal.go
@@ -27,20 +27,15 @@ func RunInternalConfigGet(viperKey string) (err error) {
 			continue
 		}
 
+		vVal, _, err := profiles.ViperValueFromOption(opt)
+		if err != nil {
+			return fmt.Errorf("failed to get configuration: %v", err)
+		}
+
 		if opt.Sensitive {
-			optVal, err := profiles.GetSensitiveOptionValue(opt, true)
-			if err != nil {
-				return fmt.Errorf("failed to get configuration: %v", err)
-			}
-
-			msgStr += fmt.Sprintf("%s=%s\n", opt.ViperKey, optVal)
+			msgStr += fmt.Sprintf("%s=%s\n", opt.ViperKey, profiles.MaskValue(vVal))
 		} else {
-			optVal, err := profiles.GetOptionValue(opt)
-			if err != nil {
-				return fmt.Errorf("failed to get configuration: %v", err)
-			}
-
-			msgStr += fmt.Sprintf("%s=%s\n", opt.ViperKey, optVal)
+			msgStr += fmt.Sprintf("%s=%s\n", opt.ViperKey, vVal)
 		}
 	}
 

--- a/internal/commands/config/get_internal.go
+++ b/internal/commands/config/get_internal.go
@@ -2,6 +2,7 @@ package config_internal
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/pingidentity/pingcli/internal/configuration"
 	"github.com/pingidentity/pingcli/internal/configuration/options"
@@ -19,12 +20,31 @@ func RunInternalConfigGet(viperKey string) (err error) {
 		return fmt.Errorf("failed to get configuration: %v", err)
 	}
 
-	yamlStr, err := profiles.GetMainConfig().ProfileViperValue(pName, viperKey)
-	if err != nil {
-		return fmt.Errorf("failed to get configuration: %v", err)
+	msgStr := fmt.Sprintf("Configuration values for profile '%s' and key '%s':\n", pName, viperKey)
+
+	for _, opt := range options.Options() {
+		if opt.ViperKey == "" || !strings.Contains(opt.ViperKey, viperKey) {
+			continue
+		}
+
+		if opt.Sensitive {
+			optVal, err := profiles.GetSensitiveOptionValue(opt, true)
+			if err != nil {
+				return fmt.Errorf("failed to get configuration: %v", err)
+			}
+
+			msgStr += fmt.Sprintf("%s=%s\n", opt.ViperKey, optVal)
+		} else {
+			optVal, err := profiles.GetOptionValue(opt)
+			if err != nil {
+				return fmt.Errorf("failed to get configuration: %v", err)
+			}
+
+			msgStr += fmt.Sprintf("%s=%s\n", opt.ViperKey, optVal)
+		}
 	}
 
-	output.Message(yamlStr, nil)
+	output.Message(msgStr, nil)
 
 	return nil
 }
@@ -37,11 +57,11 @@ func readConfigGetOptions() (pName string, err error) {
 	}
 
 	if err != nil {
-		return pName, err
+		return "", err
 	}
 
 	if pName == "" {
-		return pName, fmt.Errorf("unable to determine profile to get configuration from")
+		return "", fmt.Errorf("unable to determine profile to get configuration from")
 	}
 
 	return pName, nil

--- a/internal/commands/config/set_internal.go
+++ b/internal/commands/config/set_internal.go
@@ -45,12 +45,24 @@ func RunInternalConfigSet(kvPair string) (err error) {
 		return fmt.Errorf("failed to set configuration: %v", err)
 	}
 
-	yamlStr, err := profiles.GetMainConfig().ProfileToString(pName)
-	if err != nil {
-		return fmt.Errorf("failed to set configuration: %v", err)
+	msgStr := "Configuration set successfully: \n"
+	if opt.Sensitive {
+		optVal, err := profiles.GetSensitiveOptionValue(opt, true)
+		if err != nil {
+			return fmt.Errorf("failed to set configuration: %v", err)
+		}
+
+		msgStr += fmt.Sprintf("%s=%s\n", vKey, optVal)
+	} else {
+		optVal, err := profiles.GetOptionValue(opt)
+		if err != nil {
+			return fmt.Errorf("failed to set configuration: %v", err)
+		}
+
+		msgStr += fmt.Sprintf("%s=%s\n", vKey, optVal)
 	}
 
-	output.Success("Configuration set successfully", map[string]interface{}{"Profile YAML": yamlStr})
+	output.Success(msgStr, nil)
 
 	return nil
 }

--- a/internal/commands/config/set_internal.go
+++ b/internal/commands/config/set_internal.go
@@ -45,21 +45,17 @@ func RunInternalConfigSet(kvPair string) (err error) {
 		return fmt.Errorf("failed to set configuration: %v", err)
 	}
 
-	msgStr := "Configuration set successfully: \n"
+	msgStr := "Configuration set successfully:\n"
+
+	vVal, _, err := profiles.ViperValueFromOption(opt)
+	if err != nil {
+		return fmt.Errorf("failed to set configuration: %v", err)
+	}
+
 	if opt.Sensitive {
-		optVal, err := profiles.GetSensitiveOptionValue(opt, true)
-		if err != nil {
-			return fmt.Errorf("failed to set configuration: %v", err)
-		}
-
-		msgStr += fmt.Sprintf("%s=%s\n", vKey, optVal)
+		msgStr += fmt.Sprintf("%s=%s", vKey, profiles.MaskValue(vVal))
 	} else {
-		optVal, err := profiles.GetOptionValue(opt)
-		if err != nil {
-			return fmt.Errorf("failed to set configuration: %v", err)
-		}
-
-		msgStr += fmt.Sprintf("%s=%s\n", vKey, optVal)
+		msgStr += fmt.Sprintf("%s=%s", vKey, vVal)
 	}
 
 	output.Success(msgStr, nil)

--- a/internal/commands/config/unset_internal.go
+++ b/internal/commands/config/unset_internal.go
@@ -35,21 +35,17 @@ func RunInternalConfigUnset(viperKey string) (err error) {
 		return fmt.Errorf("failed to unset configuration: %v", err)
 	}
 
-	msgStr := "Configuration unset successfully: \n"
+	msgStr := "Configuration unset successfully:\n"
+
+	vVal, _, err := profiles.ViperValueFromOption(opt)
+	if err != nil {
+		return fmt.Errorf("failed to set configuration: %v", err)
+	}
+
 	if opt.Sensitive {
-		optVal, err := profiles.GetSensitiveOptionValue(opt, true)
-		if err != nil {
-			return fmt.Errorf("failed to unset configuration: %v", err)
-		}
-
-		msgStr += fmt.Sprintf("%s=%s\n", viperKey, optVal)
+		msgStr += fmt.Sprintf("%s=%s", viperKey, profiles.MaskValue(vVal))
 	} else {
-		optVal, err := profiles.GetOptionValue(opt)
-		if err != nil {
-			return fmt.Errorf("failed to unset configuration: %v", err)
-		}
-
-		msgStr += fmt.Sprintf("%s=%s\n", viperKey, optVal)
+		msgStr += fmt.Sprintf("%s=%s", viperKey, vVal)
 	}
 
 	output.Success(msgStr, nil)

--- a/internal/commands/config/unset_internal.go
+++ b/internal/commands/config/unset_internal.go
@@ -35,12 +35,24 @@ func RunInternalConfigUnset(viperKey string) (err error) {
 		return fmt.Errorf("failed to unset configuration: %v", err)
 	}
 
-	yamlStr, err := profiles.GetMainConfig().ProfileToString(pName)
-	if err != nil {
-		return fmt.Errorf("failed to unset configuration: %v", err)
+	msgStr := "Configuration unset successfully: \n"
+	if opt.Sensitive {
+		optVal, err := profiles.GetSensitiveOptionValue(opt, true)
+		if err != nil {
+			return fmt.Errorf("failed to unset configuration: %v", err)
+		}
+
+		msgStr += fmt.Sprintf("%s=%s\n", viperKey, optVal)
+	} else {
+		optVal, err := profiles.GetOptionValue(opt)
+		if err != nil {
+			return fmt.Errorf("failed to unset configuration: %v", err)
+		}
+
+		msgStr += fmt.Sprintf("%s=%s\n", viperKey, optVal)
 	}
 
-	output.Success("Configuration unset successfully", map[string]interface{}{"Profile YAML": yamlStr})
+	output.Success(msgStr, nil)
 
 	return nil
 }

--- a/internal/commands/config/view_profile_internal.go
+++ b/internal/commands/config/view_profile_internal.go
@@ -2,6 +2,8 @@ package config_internal
 
 import (
 	"fmt"
+	"slices"
+	"strings"
 
 	"github.com/pingidentity/pingcli/internal/configuration/options"
 	"github.com/pingidentity/pingcli/internal/output"
@@ -19,14 +21,37 @@ func RunInternalConfigViewProfile(args []string) (err error) {
 		}
 	}
 
-	profileStr, err := profiles.GetMainConfig().ProfileToString(pName)
-	if err != nil {
-		return fmt.Errorf("failed to view profile: %v", err)
+	msgStr := fmt.Sprintf("Configuration for profile '%s':\n", pName)
+
+	// Sort the options list by viper key
+	optList := options.Options()
+	slices.SortFunc(optList, func(opt1, opt2 options.Option) int {
+		return strings.Compare(opt1.ViperKey, opt2.ViperKey)
+	})
+
+	for _, opt := range optList {
+		if opt.ViperKey == "" {
+			continue
+		}
+
+		if opt.Sensitive {
+			optVal, err := profiles.GetSensitiveOptionValue(opt, true)
+			if err != nil {
+				return fmt.Errorf("failed to view profile: %v", err)
+			}
+
+			msgStr += fmt.Sprintf("%s=%s\n", opt.ViperKey, optVal)
+		} else {
+			optVal, err := profiles.GetOptionValue(opt)
+			if err != nil {
+				return fmt.Errorf("failed to view profile: %v", err)
+			}
+
+			msgStr += fmt.Sprintf("%s=%s\n", opt.ViperKey, optVal)
+		}
 	}
 
-	profileStr = fmt.Sprintf("Profile: %s\n\n%s", pName, profileStr)
-
-	output.Message(profileStr, nil)
+	output.Message(msgStr, nil)
 
 	return nil
 }

--- a/internal/commands/config/view_profile_internal.go
+++ b/internal/commands/config/view_profile_internal.go
@@ -21,6 +21,12 @@ func RunInternalConfigViewProfile(args []string) (err error) {
 		}
 	}
 
+	// Validate the profile name
+	err = profiles.GetMainConfig().ValidateExistingProfileName(pName)
+	if err != nil {
+		return fmt.Errorf("failed to view profile: %v", err)
+	}
+
 	msgStr := fmt.Sprintf("Configuration for profile '%s':\n", pName)
 
 	// Sort the options list by viper key
@@ -34,20 +40,15 @@ func RunInternalConfigViewProfile(args []string) (err error) {
 			continue
 		}
 
+		vVal, _, err := profiles.ViperValueFromOption(opt)
+		if err != nil {
+			return fmt.Errorf("failed to view profile: %v", err)
+		}
+
 		if opt.Sensitive {
-			optVal, err := profiles.GetSensitiveOptionValue(opt, true)
-			if err != nil {
-				return fmt.Errorf("failed to view profile: %v", err)
-			}
-
-			msgStr += fmt.Sprintf("%s=%s\n", opt.ViperKey, optVal)
+			msgStr += fmt.Sprintf("%s=%s\n", opt.ViperKey, profiles.MaskValue(vVal))
 		} else {
-			optVal, err := profiles.GetOptionValue(opt)
-			if err != nil {
-				return fmt.Errorf("failed to view profile: %v", err)
-			}
-
-			msgStr += fmt.Sprintf("%s=%s\n", opt.ViperKey, optVal)
+			msgStr += fmt.Sprintf("%s=%s\n", opt.ViperKey, vVal)
 		}
 	}
 

--- a/internal/commands/config/view_profile_internal.go
+++ b/internal/commands/config/view_profile_internal.go
@@ -2,8 +2,6 @@ package config_internal
 
 import (
 	"fmt"
-	"slices"
-	"strings"
 
 	"github.com/pingidentity/pingcli/internal/configuration/options"
 	"github.com/pingidentity/pingcli/internal/output"
@@ -29,13 +27,7 @@ func RunInternalConfigViewProfile(args []string) (err error) {
 
 	msgStr := fmt.Sprintf("Configuration for profile '%s':\n", pName)
 
-	// Sort the options list by viper key
-	optList := options.Options()
-	slices.SortFunc(optList, func(opt1, opt2 options.Option) int {
-		return strings.Compare(opt1.ViperKey, opt2.ViperKey)
-	})
-
-	for _, opt := range optList {
+	for _, opt := range options.Options() {
 		if opt.ViperKey == "" {
 			continue
 		}

--- a/internal/commands/platform/export_internal.go
+++ b/internal/commands/platform/export_internal.go
@@ -151,11 +151,11 @@ func initPingFederateServices(ctx context.Context, pingcliVersion string) (err e
 
 	switch {
 	case strings.EqualFold(authType, customtypes.ENUM_PINGFEDERATE_AUTHENTICATION_TYPE_BASIC):
-		pfUsername, err := profiles.GetSensitiveOptionValue(options.PingFederateBasicAuthUsernameOption, false)
+		pfUsername, err := profiles.GetOptionValue(options.PingFederateBasicAuthUsernameOption)
 		if err != nil {
 			return err
 		}
-		pfPassword, err := profiles.GetSensitiveOptionValue(options.PingFederateBasicAuthPasswordOption, false)
+		pfPassword, err := profiles.GetOptionValue(options.PingFederateBasicAuthPasswordOption)
 		if err != nil {
 			return err
 		}
@@ -169,7 +169,7 @@ func initPingFederateServices(ctx context.Context, pingcliVersion string) (err e
 			Password: pfPassword,
 		})
 	case strings.EqualFold(authType, customtypes.ENUM_PINGFEDERATE_AUTHENTICATION_TYPE_ACCESS_TOKEN):
-		pfAccessToken, err := profiles.GetSensitiveOptionValue(options.PingFederateAccessTokenAuthAccessTokenOption, false)
+		pfAccessToken, err := profiles.GetOptionValue(options.PingFederateAccessTokenAuthAccessTokenOption)
 		if err != nil {
 			return err
 		}
@@ -180,11 +180,11 @@ func initPingFederateServices(ctx context.Context, pingcliVersion string) (err e
 
 		pingfederateContext = context.WithValue(ctx, pingfederateGoClient.ContextAccessToken, pfAccessToken)
 	case strings.EqualFold(authType, customtypes.ENUM_PINGFEDERATE_AUTHENTICATION_TYPE_CLIENT_CREDENTIALS):
-		pfClientID, err := profiles.GetSensitiveOptionValue(options.PingFederateClientCredentialsAuthClientIDOption, false)
+		pfClientID, err := profiles.GetOptionValue(options.PingFederateClientCredentialsAuthClientIDOption)
 		if err != nil {
 			return err
 		}
-		pfClientSecret, err := profiles.GetSensitiveOptionValue(options.PingFederateClientCredentialsAuthClientSecretOption, false)
+		pfClientSecret, err := profiles.GetOptionValue(options.PingFederateClientCredentialsAuthClientSecretOption)
 		if err != nil {
 			return err
 		}
@@ -294,11 +294,11 @@ func initPingOneApiClient(ctx context.Context, pingcliVersion string) (err error
 		return fmt.Errorf("failed to initialize pingone API client. context is nil")
 	}
 
-	pingoneApiClientId, err = profiles.GetSensitiveOptionValue(options.PingOneAuthenticationWorkerClientIDOption, false)
+	pingoneApiClientId, err = profiles.GetOptionValue(options.PingOneAuthenticationWorkerClientIDOption)
 	if err != nil {
 		return err
 	}
-	clientSecret, err := profiles.GetSensitiveOptionValue(options.PingOneAuthenticationWorkerClientSecretOption, false)
+	clientSecret, err := profiles.GetOptionValue(options.PingOneAuthenticationWorkerClientSecretOption)
 	if err != nil {
 		return err
 	}

--- a/internal/commands/platform/export_internal.go
+++ b/internal/commands/platform/export_internal.go
@@ -151,11 +151,11 @@ func initPingFederateServices(ctx context.Context, pingcliVersion string) (err e
 
 	switch {
 	case strings.EqualFold(authType, customtypes.ENUM_PINGFEDERATE_AUTHENTICATION_TYPE_BASIC):
-		pfUsername, err := profiles.GetOptionValue(options.PingFederateBasicAuthUsernameOption)
+		pfUsername, err := profiles.GetSensitiveOptionValue(options.PingFederateBasicAuthUsernameOption, false)
 		if err != nil {
 			return err
 		}
-		pfPassword, err := profiles.GetOptionValue(options.PingFederateBasicAuthPasswordOption)
+		pfPassword, err := profiles.GetSensitiveOptionValue(options.PingFederateBasicAuthPasswordOption, false)
 		if err != nil {
 			return err
 		}
@@ -169,7 +169,7 @@ func initPingFederateServices(ctx context.Context, pingcliVersion string) (err e
 			Password: pfPassword,
 		})
 	case strings.EqualFold(authType, customtypes.ENUM_PINGFEDERATE_AUTHENTICATION_TYPE_ACCESS_TOKEN):
-		pfAccessToken, err := profiles.GetOptionValue(options.PingFederateAccessTokenAuthAccessTokenOption)
+		pfAccessToken, err := profiles.GetSensitiveOptionValue(options.PingFederateAccessTokenAuthAccessTokenOption, false)
 		if err != nil {
 			return err
 		}
@@ -180,11 +180,11 @@ func initPingFederateServices(ctx context.Context, pingcliVersion string) (err e
 
 		pingfederateContext = context.WithValue(ctx, pingfederateGoClient.ContextAccessToken, pfAccessToken)
 	case strings.EqualFold(authType, customtypes.ENUM_PINGFEDERATE_AUTHENTICATION_TYPE_CLIENT_CREDENTIALS):
-		pfClientID, err := profiles.GetOptionValue(options.PingFederateClientCredentialsAuthClientIDOption)
+		pfClientID, err := profiles.GetSensitiveOptionValue(options.PingFederateClientCredentialsAuthClientIDOption, false)
 		if err != nil {
 			return err
 		}
-		pfClientSecret, err := profiles.GetOptionValue(options.PingFederateClientCredentialsAuthClientSecretOption)
+		pfClientSecret, err := profiles.GetSensitiveOptionValue(options.PingFederateClientCredentialsAuthClientSecretOption, false)
 		if err != nil {
 			return err
 		}
@@ -294,11 +294,11 @@ func initPingOneApiClient(ctx context.Context, pingcliVersion string) (err error
 		return fmt.Errorf("failed to initialize pingone API client. context is nil")
 	}
 
-	pingoneApiClientId, err = profiles.GetOptionValue(options.PingOneAuthenticationWorkerClientIDOption)
+	pingoneApiClientId, err = profiles.GetSensitiveOptionValue(options.PingOneAuthenticationWorkerClientIDOption, false)
 	if err != nil {
 		return err
 	}
-	clientSecret, err := profiles.GetOptionValue(options.PingOneAuthenticationWorkerClientSecretOption)
+	clientSecret, err := profiles.GetSensitiveOptionValue(options.PingOneAuthenticationWorkerClientSecretOption, false)
 	if err != nil {
 		return err
 	}
@@ -335,19 +335,8 @@ func initPingOneApiClient(ctx context.Context, pingcliVersion string) (err error
 
 	pingoneApiClient, err = apiConfig.APIClient(ctx)
 	if err != nil {
-		return fmt.Errorf(`failed to initialize pingone API client.
-%v
-
-configuration values used for client initialization:
-worker client ID - %s
-worker client secret - %s
-worker environment ID - %s
-pingone region - %s`,
-			err,
-			pingoneApiClientId,
-			strings.Repeat("*", len(clientSecret)),
-			environmentID,
-			regionCode)
+		return fmt.Errorf("failed to initialize pingone API client. Check worker client ID, worker client secret,"+
+			" worker environment ID, and pingone region code configuration values. %v", err)
 	}
 
 	return nil

--- a/internal/commands/request/request_internal.go
+++ b/internal/commands/request/request_internal.go
@@ -148,7 +148,7 @@ func getTopLevelDomain() (topLevelDomain string, err error) {
 
 func pingoneAccessToken() (accessToken string, err error) {
 	// Check if existing access token is available
-	accessToken, err = profiles.GetSensitiveOptionValue(options.RequestAccessTokenOption, false)
+	accessToken, err = profiles.GetOptionValue(options.RequestAccessTokenOption)
 	if err != nil {
 		return "", err
 	}
@@ -201,11 +201,11 @@ func pingoneAuth() (accessToken string, err error) {
 
 	authURL := fmt.Sprintf("https://auth.pingone.%s/%s/as/token", topLevelDomain, workerEnvId)
 
-	clientId, err := profiles.GetSensitiveOptionValue(options.PingOneAuthenticationWorkerClientIDOption, false)
+	clientId, err := profiles.GetOptionValue(options.PingOneAuthenticationWorkerClientIDOption)
 	if err != nil {
 		return "", err
 	}
-	clientSecret, err := profiles.GetSensitiveOptionValue(options.PingOneAuthenticationWorkerClientSecretOption, false)
+	clientSecret, err := profiles.GetOptionValue(options.PingOneAuthenticationWorkerClientSecretOption)
 	if err != nil {
 		return "", err
 	}

--- a/internal/commands/request/request_internal.go
+++ b/internal/commands/request/request_internal.go
@@ -148,7 +148,7 @@ func getTopLevelDomain() (topLevelDomain string, err error) {
 
 func pingoneAccessToken() (accessToken string, err error) {
 	// Check if existing access token is available
-	accessToken, err = profiles.GetOptionValue(options.RequestAccessTokenOption)
+	accessToken, err = profiles.GetSensitiveOptionValue(options.RequestAccessTokenOption, false)
 	if err != nil {
 		return "", err
 	}
@@ -201,11 +201,11 @@ func pingoneAuth() (accessToken string, err error) {
 
 	authURL := fmt.Sprintf("https://auth.pingone.%s/%s/as/token", topLevelDomain, workerEnvId)
 
-	clientId, err := profiles.GetOptionValue(options.PingOneAuthenticationWorkerClientIDOption)
+	clientId, err := profiles.GetSensitiveOptionValue(options.PingOneAuthenticationWorkerClientIDOption, false)
 	if err != nil {
 		return "", err
 	}
-	clientSecret, err := profiles.GetOptionValue(options.PingOneAuthenticationWorkerClientSecretOption)
+	clientSecret, err := profiles.GetSensitiveOptionValue(options.PingOneAuthenticationWorkerClientSecretOption, false)
 	if err != nil {
 		return "", err
 	}

--- a/internal/configuration/config/add_profile.go
+++ b/internal/configuration/config/add_profile.go
@@ -28,8 +28,9 @@ func initAddProfileDescriptionOption() {
 			Usage:     "The description of the new configuration profile.",
 			Value:     cobraValue,
 		},
-		Type:     options.ENUM_STRING,
-		ViperKey: "", // No viper key
+		Sensitive: false,
+		Type:      options.ENUM_STRING,
+		ViperKey:  "", // No viper key
 	}
 }
 
@@ -49,8 +50,9 @@ func initAddProfileNameOption() {
 			Usage:     "The name of the new configuration profile.",
 			Value:     cobraValue,
 		},
-		Type:     options.ENUM_STRING,
-		ViperKey: "", // No viper key
+		Sensitive: false,
+		Type:      options.ENUM_STRING,
+		ViperKey:  "", // No viper key
 	}
 }
 
@@ -72,7 +74,8 @@ func initAddProfileSetActiveOption() {
 			Value:       cobraValue,
 			NoOptDefVal: "true", // Make this flag a boolean flag
 		},
-		Type:     options.ENUM_BOOL,
-		ViperKey: "", // No viper key
+		Sensitive: false,
+		Type:      options.ENUM_BOOL,
+		ViperKey:  "", // No viper key
 	}
 }

--- a/internal/configuration/config/delete_profile.go
+++ b/internal/configuration/config/delete_profile.go
@@ -28,7 +28,8 @@ func initDeleteAutoAcceptOption() {
 			Value:       cobraValue,
 			NoOptDefVal: "true", // Make the flag a boolean flag
 		},
-		Type:     options.ENUM_STRING,
-		ViperKey: "", // No viper key
+		Sensitive: false,
+		Type:      options.ENUM_STRING,
+		ViperKey:  "", // No viper key
 	}
 }

--- a/internal/configuration/options/options.go
+++ b/internal/configuration/options/options.go
@@ -27,6 +27,7 @@ type Option struct {
 	DefaultValue    pflag.Value
 	EnvVar          string
 	Flag            *pflag.Flag
+	Sensitive       bool
 	Type            OptionType
 	ViperKey        string
 }

--- a/internal/configuration/options/options.go
+++ b/internal/configuration/options/options.go
@@ -1,6 +1,11 @@
 package options
 
-import "github.com/spf13/pflag"
+import (
+	"slices"
+	"strings"
+
+	"github.com/spf13/pflag"
+)
 
 type OptionType string
 
@@ -33,7 +38,7 @@ type Option struct {
 }
 
 func Options() []Option {
-	return []Option{
+	optList := []Option{
 		PingOneAuthenticationTypeOption,
 		PingOneAuthenticationWorkerClientIDOption,
 		PingOneAuthenticationWorkerClientSecretOption,
@@ -80,6 +85,13 @@ func Options() []Option {
 		RequestAccessTokenExpiryOption,
 		RequestFailOption,
 	}
+
+	// Sort the options list by viper key
+	slices.SortFunc(optList, func(opt1, opt2 Option) int {
+		return strings.Compare(opt1.ViperKey, opt2.ViperKey)
+	})
+
+	return optList
 }
 
 // pingone service options

--- a/internal/configuration/platform/export.go
+++ b/internal/configuration/platform/export.go
@@ -39,8 +39,9 @@ func initFormatOption() {
 			),
 			Value: cobraValue,
 		},
-		Type:     options.ENUM_STRING,
-		ViperKey: "export.format",
+		Sensitive: false,
+		Type:      options.ENUM_STRING,
+		ViperKey:  "export.format",
 	}
 }
 
@@ -71,8 +72,9 @@ func initServicesOption() {
 			),
 			Value: cobraValue,
 		},
-		Type:     options.ENUM_EXPORT_SERVICES,
-		ViperKey: "export.services",
+		Sensitive: false,
+		Type:      options.ENUM_EXPORT_SERVICES,
+		ViperKey:  "export.services",
 	}
 }
 
@@ -96,8 +98,9 @@ func initOutputDirectoryOption() {
 				"\nExample: 'pingcli-export'",
 			Value: cobraValue,
 		},
-		Type:     options.ENUM_STRING,
-		ViperKey: "export.outputDirectory",
+		Sensitive: false,
+		Type:      options.ENUM_STRING,
+		ViperKey:  "export.outputDirectory",
 	}
 }
 
@@ -119,8 +122,9 @@ func initOverwriteOption() {
 			Value:       cobraValue,
 			NoOptDefVal: "true", // Make this flag a boolean flag
 		},
-		Type:     options.ENUM_BOOL,
-		ViperKey: "export.overwrite",
+		Sensitive: false,
+		Type:      options.ENUM_BOOL,
+		ViperKey:  "export.overwrite",
 	}
 }
 
@@ -140,7 +144,8 @@ func initPingOneEnvironmentIDOption() {
 			Usage: "The ID of the PingOne environment to export. Must be a valid PingOne UUID.",
 			Value: cobraValue,
 		},
-		Type:     options.ENUM_UUID,
-		ViperKey: "export.pingone.environmentID",
+		Sensitive: false,
+		Type:      options.ENUM_UUID,
+		ViperKey:  "export.pingone.environmentID",
 	}
 }

--- a/internal/configuration/profiles/profiles.go
+++ b/internal/configuration/profiles/profiles.go
@@ -16,6 +16,7 @@ func initDescriptionOption() {
 		DefaultValue:    new(customtypes.String),
 		EnvVar:          "",  // No environment variable
 		Flag:            nil, // No flag
+		Sensitive:       false,
 		Type:            options.ENUM_STRING,
 		ViperKey:        "description",
 	}

--- a/internal/configuration/request/request.go
+++ b/internal/configuration/request/request.go
@@ -35,8 +35,9 @@ func initDataOption() {
 				"\nExample: '@data.json'",
 			Value: cobraValue,
 		},
-		Type:     options.ENUM_STRING,
-		ViperKey: "", // No viper key
+		Sensitive: false,
+		Type:      options.ENUM_STRING,
+		ViperKey:  "", // No viper key
 	}
 }
 
@@ -63,8 +64,9 @@ func initHTTPMethodOption() {
 			),
 			Value: cobraValue,
 		},
-		Type:     options.ENUM_REQUEST_HTTP_METHOD,
-		ViperKey: "", // No viper key
+		Sensitive: false,
+		Type:      options.ENUM_REQUEST_HTTP_METHOD,
+		ViperKey:  "", // No viper key
 	}
 }
 
@@ -91,8 +93,9 @@ func initServiceOption() {
 			),
 			Value: cobraValue,
 		},
-		Type:     options.ENUM_REQUEST_SERVICE,
-		ViperKey: "request.service",
+		Sensitive: false,
+		Type:      options.ENUM_REQUEST_SERVICE,
+		ViperKey:  "request.service",
 	}
 }
 
@@ -105,6 +108,7 @@ func initAccessTokenOption() {
 		DefaultValue:    &defaultValue,
 		EnvVar:          "", // No environment variable
 		Flag:            nil,
+		Sensitive:       true,
 		Type:            options.ENUM_STRING,
 		ViperKey:        "request.accessToken",
 	}
@@ -119,6 +123,7 @@ func initAccessTokenExpiryOption() {
 		DefaultValue:    &defaultValue,
 		EnvVar:          "",  // No environment variable
 		Flag:            nil, // No flag
+		Sensitive:       false,
 		Type:            options.ENUM_INT,
 		ViperKey:        "request.accessTokenExpiry",
 	}
@@ -140,8 +145,8 @@ func initFailOption() {
 			Usage:       "Return non-zero exit code when HTTP custom request returns a failure status code.",
 			Value:       cobraValue,
 		},
-
-		Type:     options.ENUM_BOOL,
-		ViperKey: "request.fail",
+		Sensitive: false,
+		Type:      options.ENUM_BOOL,
+		ViperKey:  "request.fail",
 	}
 }

--- a/internal/configuration/root/root.go
+++ b/internal/configuration/root/root.go
@@ -28,6 +28,7 @@ func initActiveProfileOption() {
 		DefaultValue:    &defaultValue,
 		EnvVar:          "",  // No env var
 		Flag:            nil, // No flag
+		Sensitive:       false,
 		Type:            options.ENUM_STRING,
 		ViperKey:        "activeProfile",
 	}
@@ -49,8 +50,9 @@ func initProfileOption() {
 			Usage:     "The name of a configuration profile to use.",
 			Value:     cobraValue,
 		},
-		Type:     options.ENUM_STRING,
-		ViperKey: "", // No viper key
+		Sensitive: false,
+		Type:      options.ENUM_STRING,
+		ViperKey:  "", // No viper key
 	}
 }
 
@@ -70,8 +72,9 @@ func initColorOption() {
 			Value:       cobraValue,
 			NoOptDefVal: "true", // Make this flag a boolean flag
 		},
-		Type:     options.ENUM_BOOL,
-		ViperKey: "noColor",
+		Sensitive: false,
+		Type:      options.ENUM_BOOL,
+		ViperKey:  "noColor",
 	}
 }
 
@@ -92,8 +95,9 @@ func initConfigOption() {
 				"(default $HOME/.pingcli/config.yaml)",
 			Value: cobraValue,
 		},
-		Type:     options.ENUM_STRING,
-		ViperKey: "", // No viper key
+		Sensitive: false,
+		Type:      options.ENUM_STRING,
+		ViperKey:  "", // No viper key
 	}
 }
 
@@ -119,8 +123,9 @@ func initOutputFormatOption() {
 			),
 			Value: cobraValue,
 		},
-		Type:     options.ENUM_OUTPUT_FORMAT,
-		ViperKey: "outputFormat",
+		Sensitive: false,
+		Type:      options.ENUM_OUTPUT_FORMAT,
+		ViperKey:  "outputFormat",
 	}
 }
 

--- a/internal/configuration/services/pingfederate.go
+++ b/internal/configuration/services/pingfederate.go
@@ -42,8 +42,9 @@ func initHTTPSHostOption() {
 				"\nExample: 'https://pingfederate-admin.bxretail.org'",
 			Value: cobraValue,
 		},
-		Type:     options.ENUM_STRING,
-		ViperKey: "service.pingfederate.httpsHost",
+		Sensitive: false,
+		Type:      options.ENUM_STRING,
+		ViperKey:  "service.pingfederate.httpsHost",
 	}
 }
 
@@ -64,8 +65,9 @@ func initAdminAPIPathOption() {
 				"(default /pf-admin-api/v1)",
 			Value: cobraValue,
 		},
-		Type:     options.ENUM_STRING,
-		ViperKey: "service.pingfederate.adminAPIPath",
+		Sensitive: false,
+		Type:      options.ENUM_STRING,
+		ViperKey:  "service.pingfederate.adminAPIPath",
 	}
 }
 
@@ -88,8 +90,9 @@ func initXBypassExternalValidationHeaderOption() {
 			Value:       cobraValue,
 			NoOptDefVal: "true", // Make this flag a boolean flag
 		},
-		Type:     options.ENUM_BOOL,
-		ViperKey: "service.pingfederate.xBypassExternalValidationHeader",
+		Sensitive: false,
+		Type:      options.ENUM_BOOL,
+		ViperKey:  "service.pingfederate.xBypassExternalValidationHeader",
 	}
 }
 
@@ -112,8 +115,9 @@ func initCACertificatePemFilesOption() {
 				"\nAccepts a comma-separated string to delimit multiple PEM files.",
 			Value: cobraValue,
 		},
-		Type:     options.ENUM_STRING_SLICE,
-		ViperKey: "service.pingfederate.caCertificatePemFiles",
+		Sensitive: false,
+		Type:      options.ENUM_STRING_SLICE,
+		ViperKey:  "service.pingfederate.caCertificatePemFiles",
 	}
 }
 
@@ -136,8 +140,9 @@ func initInsecureTrustAllTLSOption() {
 			Value:       cobraValue,
 			NoOptDefVal: "true", // Make this flag a boolean flag
 		},
-		Type:     options.ENUM_BOOL,
-		ViperKey: "service.pingfederate.insecureTrustAllTLS",
+		Sensitive: false,
+		Type:      options.ENUM_BOOL,
+		ViperKey:  "service.pingfederate.insecureTrustAllTLS",
 	}
 }
 
@@ -159,8 +164,9 @@ func initUsernameOption() {
 				"\nExample: 'administrator'",
 			Value: cobraValue,
 		},
-		Type:     options.ENUM_STRING,
-		ViperKey: "service.pingfederate.authentication.basicAuth.username",
+		Sensitive: true,
+		Type:      options.ENUM_STRING,
+		ViperKey:  "service.pingfederate.authentication.basicAuth.username",
 	}
 }
 
@@ -181,8 +187,9 @@ func initPasswordOption() {
 				"authentication.",
 			Value: cobraValue,
 		},
-		Type:     options.ENUM_STRING,
-		ViperKey: "service.pingfederate.authentication.basicAuth.password",
+		Sensitive: true,
+		Type:      options.ENUM_STRING,
+		ViperKey:  "service.pingfederate.authentication.basicAuth.password",
 	}
 }
 
@@ -203,8 +210,9 @@ func initAccessTokenOption() {
 				"custom OAuth 2.0 token method.",
 			Value: cobraValue,
 		},
-		Type:     options.ENUM_STRING,
-		ViperKey: "service.pingfederate.authentication.accessTokenAuth.accessToken",
+		Sensitive: true,
+		Type:      options.ENUM_STRING,
+		ViperKey:  "service.pingfederate.authentication.accessTokenAuth.accessToken",
 	}
 }
 
@@ -225,8 +233,9 @@ func initClientIDOption() {
 				"the OAuth 2.0 client credentials grant type.",
 			Value: cobraValue,
 		},
-		Type:     options.ENUM_STRING,
-		ViperKey: "service.pingfederate.authentication.clientCredentialsAuth.clientID",
+		Sensitive: true,
+		Type:      options.ENUM_STRING,
+		ViperKey:  "service.pingfederate.authentication.clientCredentialsAuth.clientID",
 	}
 }
 
@@ -247,8 +256,9 @@ func initClientSecretOption() {
 				"using the OAuth 2.0 client credentials grant type.",
 			Value: cobraValue,
 		},
-		Type:     options.ENUM_STRING,
-		ViperKey: "service.pingfederate.authentication.clientCredentialsAuth.clientSecret",
+		Sensitive: true,
+		Type:      options.ENUM_STRING,
+		ViperKey:  "service.pingfederate.authentication.clientCredentialsAuth.clientSecret",
 	}
 }
 
@@ -269,8 +279,9 @@ func initTokenURLOption() {
 				"the OAuth 2.0 client credentials grant type.",
 			Value: cobraValue,
 		},
-		Type:     options.ENUM_STRING,
-		ViperKey: "service.pingfederate.authentication.clientCredentialsAuth.tokenURL",
+		Sensitive: false,
+		Type:      options.ENUM_STRING,
+		ViperKey:  "service.pingfederate.authentication.clientCredentialsAuth.tokenURL",
 	}
 }
 
@@ -294,8 +305,9 @@ func initScopesOption() {
 				"\nExample: 'openid,profile'",
 			Value: cobraValue,
 		},
-		Type:     options.ENUM_STRING_SLICE,
-		ViperKey: "service.pingfederate.authentication.clientCredentialsAuth.scopes",
+		Sensitive: false,
+		Type:      options.ENUM_STRING_SLICE,
+		ViperKey:  "service.pingfederate.authentication.clientCredentialsAuth.scopes",
 	}
 }
 
@@ -321,7 +333,8 @@ func initPingFederateAuthenticationTypeOption() {
 			),
 			Value: cobraValue,
 		},
-		Type:     options.ENUM_PINGFEDERATE_AUTH_TYPE,
-		ViperKey: "service.pingfederate.authentication.type",
+		Sensitive: false,
+		Type:      options.ENUM_PINGFEDERATE_AUTH_TYPE,
+		ViperKey:  "service.pingfederate.authentication.type",
 	}
 }

--- a/internal/configuration/services/pingfederate.go
+++ b/internal/configuration/services/pingfederate.go
@@ -164,7 +164,7 @@ func initUsernameOption() {
 				"\nExample: 'administrator'",
 			Value: cobraValue,
 		},
-		Sensitive: true,
+		Sensitive: false,
 		Type:      options.ENUM_STRING,
 		ViperKey:  "service.pingfederate.authentication.basicAuth.username",
 	}
@@ -233,7 +233,7 @@ func initClientIDOption() {
 				"the OAuth 2.0 client credentials grant type.",
 			Value: cobraValue,
 		},
-		Sensitive: true,
+		Sensitive: false,
 		Type:      options.ENUM_STRING,
 		ViperKey:  "service.pingfederate.authentication.clientCredentialsAuth.clientID",
 	}

--- a/internal/configuration/services/pingone.go
+++ b/internal/configuration/services/pingone.go
@@ -34,8 +34,9 @@ func initAuthenticationWorkerClientIDOption() {
 			Usage: "The worker client ID used to authenticate to the PingOne management API.",
 			Value: cobraValue,
 		},
-		Type:     options.ENUM_UUID,
-		ViperKey: "service.pingone.authentication.worker.clientID",
+		Sensitive: true,
+		Type:      options.ENUM_UUID,
+		ViperKey:  "service.pingone.authentication.worker.clientID",
 	}
 }
 
@@ -55,8 +56,9 @@ func initAuthenticationWorkerClientSecretOption() {
 			Usage: "The worker client secret used to authenticate to the PingOne management API.",
 			Value: cobraValue,
 		},
-		Type:     options.ENUM_STRING,
-		ViperKey: "service.pingone.authentication.worker.clientSecret",
+		Sensitive: true,
+		Type:      options.ENUM_STRING,
+		ViperKey:  "service.pingone.authentication.worker.clientSecret",
 	}
 }
 
@@ -77,8 +79,9 @@ func initAuthenticationWorkerEnvironmentIDOption() {
 				"the PingOne management API.",
 			Value: cobraValue,
 		},
-		Type:     options.ENUM_UUID,
-		ViperKey: "service.pingone.authentication.worker.environmentID",
+		Sensitive: false,
+		Type:      options.ENUM_UUID,
+		ViperKey:  "service.pingone.authentication.worker.environmentID",
 	}
 }
 
@@ -103,8 +106,9 @@ func initPingOneAuthenticationTypeOption() {
 			),
 			Value: cobraValue,
 		},
-		Type:     options.ENUM_PINGONE_AUTH_TYPE,
-		ViperKey: "service.pingone.authentication.type",
+		Sensitive: false,
+		Type:      options.ENUM_PINGONE_AUTH_TYPE,
+		ViperKey:  "service.pingone.authentication.type",
 	}
 }
 
@@ -130,7 +134,8 @@ func initRegionCodeOption() {
 			),
 			Value: cobraValue,
 		},
-		Type:     options.ENUM_PINGONE_REGION_CODE,
-		ViperKey: "service.pingone.regionCode",
+		Sensitive: false,
+		Type:      options.ENUM_PINGONE_REGION_CODE,
+		ViperKey:  "service.pingone.regionCode",
 	}
 }

--- a/internal/configuration/services/pingone.go
+++ b/internal/configuration/services/pingone.go
@@ -34,7 +34,7 @@ func initAuthenticationWorkerClientIDOption() {
 			Usage: "The worker client ID used to authenticate to the PingOne management API.",
 			Value: cobraValue,
 		},
-		Sensitive: true,
+		Sensitive: false,
 		Type:      options.ENUM_UUID,
 		ViperKey:  "service.pingone.authentication.worker.clientID",
 	}

--- a/internal/connector/pingone/sso/resources/pingone_schema_attribute_test.go
+++ b/internal/connector/pingone/sso/resources/pingone_schema_attribute_test.go
@@ -161,6 +161,11 @@ func TestSchemaAttributeExport(t *testing.T) {
 			ResourceName: "User_username",
 			ResourceID:   fmt.Sprintf("%s/ff3cb03d-4896-4d20-8612-f014c4048d01/77d3f22e-00ca-49d1-98a1-fc0ee48d2542", testutils.GetEnvironmentID()),
 		},
+		{
+			ResourceType: "pingone_schema_attribute",
+			ResourceName: "User_bypassMFA",
+			ResourceID:   fmt.Sprintf("%s/ff3cb03d-4896-4d20-8612-f014c4048d01/355c50dc-0eb6-4c5b-ab36-2b3152e0534c", testutils.GetEnvironmentID()),
+		},
 	}
 
 	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocks)

--- a/internal/profiles/viper.go
+++ b/internal/profiles/viper.go
@@ -385,8 +385,9 @@ func MaskValue(value string) string {
 		return ""
 	}
 
-	maskLength := min(len(value), 16)
-	return fmt.Sprintf("%s (%d character(s))", strings.Repeat("*", maskLength), len(value))
+	// Mask all values to the same asterisk length
+	// providing no additional information about the value when logged.
+	return strings.Repeat("*", 8)
 }
 
 func cobraParamValueFromOption(opt options.Option) (value string, ok bool) {


### PR DESCRIPTION
- Update Option Struct to support Sensitive field.
- Update all config commands to use MaskValue on sensitive options, and flatten yaml structure output to key=value lines.
- Add test cases on config command output expectations.