### PR TITLE
remove unneeded punctuation as the symbols are included by default

### DIFF
--- a/internal/commands/config/add_profile_internal.go
+++ b/internal/commands/config/add_profile_internal.go
@@ -70,7 +70,7 @@ func readConfigAddProfileOptions(rc io.ReadCloser) (newProfileName, newDescripti
 
 func readConfigAddProfileNameOption(rc io.ReadCloser) (newProfileName string, err error) {
 	if !options.ConfigAddProfileNameOption.Flag.Changed {
-		newProfileName, err = input.RunPrompt("New profile name: ", profiles.GetMainConfig().ValidateNewProfileName, rc)
+		newProfileName, err = input.RunPrompt("New profile name", profiles.GetMainConfig().ValidateNewProfileName, rc)
 		if err != nil {
 			return newProfileName, err
 		}

--- a/internal/commands/config/delete_profile_internal.go
+++ b/internal/commands/config/delete_profile_internal.go
@@ -47,7 +47,7 @@ func RunInternalConfigDeleteProfile(args []string, rc io.ReadCloser) (err error)
 }
 
 func promptUserToDeleteProfile(rc io.ReadCloser) (pName string, err error) {
-	pName, err = input.RunPromptSelect("Select profile to delete: ", profiles.GetMainConfig().ProfileNames(), rc)
+	pName, err = input.RunPromptSelect("Select profile to delete", profiles.GetMainConfig().ProfileNames(), rc)
 
 	if err != nil {
 		return pName, err
@@ -69,7 +69,7 @@ func promptUserToConfirmDelete(pName string, rc io.ReadCloser) (confirmed bool, 
 		return true, nil
 	}
 
-	return input.RunPromptConfirm(fmt.Sprintf("Are you sure you want to delete profile '%s'?", pName), rc)
+	return input.RunPromptConfirm(fmt.Sprintf("Are you sure you want to delete profile '%s'", pName), rc)
 }
 
 func deleteProfile(pName string) (err error) {


### PR DESCRIPTION
Remove unneeded punctuations

fix:
- remove extra punctuations on `config add-profile` and `config delete-profile`