### PR TITLE
CDI-580: Support Case-Insensitive Keys in 'Config' Commands

### DIFF
--- a/internal/commands/config/set_internal.go
+++ b/internal/commands/config/set_internal.go
@@ -39,7 +39,7 @@ func RunInternalConfigSet(kvPair string) (err error) {
 		return fmt.Errorf("failed to set configuration: %w", err)
 	}
 
-	if err = setValue(subKoanf, vKey, vValue, opt.Type); err != nil {
+	if err = setValue(subKoanf, opt.KoanfKey, vValue, opt.Type); err != nil {
 		return fmt.Errorf("failed to set configuration: %w", err)
 	}
 
@@ -60,9 +60,9 @@ func RunInternalConfigSet(kvPair string) (err error) {
 	}
 
 	if opt.Sensitive && strings.EqualFold(unmaskOptionVal, "false") {
-		msgStr += fmt.Sprintf("%s=%s", vKey, profiles.MaskValue(vVal))
+		msgStr += fmt.Sprintf("%s=%s", opt.KoanfKey, profiles.MaskValue(vVal))
 	} else {
-		msgStr += fmt.Sprintf("%s=%s", vKey, vVal)
+		msgStr += fmt.Sprintf("%s=%s", opt.KoanfKey, vVal)
 	}
 
 	output.Success(msgStr, nil)

--- a/internal/commands/config/set_internal_test.go
+++ b/internal/commands/config/set_internal_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/pingidentity/pingcli/internal/configuration/options"
 	"github.com/pingidentity/pingcli/internal/customtypes"
+	"github.com/pingidentity/pingcli/internal/profiles"
 	"github.com/pingidentity/pingcli/internal/testing/testutils"
 	"github.com/pingidentity/pingcli/internal/testing/testutils_koanf"
 )
@@ -128,5 +129,15 @@ func Test_RunInternalConfigSet_CaseInsensitiveKeys(t *testing.T) {
 	err := RunInternalConfigSet("NoCoLoR=true")
 	if err != nil {
 		t.Errorf("RunInternalConfigSet returned error: %v", err)
+	}
+
+	//Make sure the actual correct key was set, not the case-insensitive one
+	vVal, err := profiles.GetOptionValue(options.RootColorOption)
+	if err != nil {
+		t.Errorf("GetOptionValue returned error: %v", err)
+	}
+
+	if vVal != "true" {
+		t.Errorf("Expected %s to be true, got %v", options.RootColorOption.KoanfKey, vVal)
 	}
 }

--- a/internal/commands/config/unset_internal.go
+++ b/internal/commands/config/unset_internal.go
@@ -32,7 +32,7 @@ func RunInternalConfigUnset(koanfKey string) (err error) {
 		return fmt.Errorf("failed to unset configuration: %w", err)
 	}
 
-	err = subKoanf.Set(koanfKey, opt.DefaultValue)
+	err = subKoanf.Set(opt.KoanfKey, opt.DefaultValue)
 	if err != nil {
 		return fmt.Errorf("failed to unset configuration: %w", err)
 	}
@@ -54,9 +54,9 @@ func RunInternalConfigUnset(koanfKey string) (err error) {
 	}
 
 	if opt.Sensitive && strings.EqualFold(unmaskOptionVal, "false") {
-		msgStr += fmt.Sprintf("%s=%s", koanfKey, profiles.MaskValue(vVal))
+		msgStr += fmt.Sprintf("%s=%s", opt.KoanfKey, profiles.MaskValue(vVal))
 	} else {
-		msgStr += fmt.Sprintf("%s=%s", koanfKey, vVal)
+		msgStr += fmt.Sprintf("%s=%s", opt.KoanfKey, vVal)
 	}
 
 	output.Success(msgStr, nil)

--- a/internal/commands/config/unset_internal_test.go
+++ b/internal/commands/config/unset_internal_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/pingidentity/pingcli/internal/configuration/options"
 	"github.com/pingidentity/pingcli/internal/customtypes"
+	"github.com/pingidentity/pingcli/internal/profiles"
 	"github.com/pingidentity/pingcli/internal/testing/testutils"
 	"github.com/pingidentity/pingcli/internal/testing/testutils_koanf"
 )
@@ -61,4 +62,24 @@ func Test_RunInternalConfigUnset_InvalidProfileName(t *testing.T) {
 	expectedErrorPattern := `^failed to unset configuration: invalid profile name: '.*' profile does not exist$`
 	err := RunInternalConfigUnset("noColor")
 	testutils.CheckExpectedError(t, err, &expectedErrorPattern)
+}
+
+// Test RunInternalConfigUnset function succeeds with case-insensitive key
+func Test_RunInternalConfigUnset_CaseInsensitiveKeys(t *testing.T) {
+	testutils_koanf.InitKoanfs(t)
+
+	err := RunInternalConfigUnset("NoCoLoR")
+	if err != nil {
+		t.Errorf("RunInternalConfigUnset returned error: %v", err)
+	}
+
+	//Make sure the actual correct key was unset, not the case-insensitive one
+	vVal, err := profiles.GetOptionValue(options.RootColorOption)
+	if err != nil {
+		t.Errorf("GetOptionValue returned error: %v", err)
+	}
+
+	if vVal != options.RootColorOption.DefaultValue.String() {
+		t.Errorf("Expected %s to be %s, got %v", options.RootColorOption.KoanfKey, options.RootColorOption.DefaultValue.String(), vVal)
+	}
 }


### PR DESCRIPTION
- Update 'set' and 'unset' subcommands to change actual keys, not the user provided case-insensitive keys.