### PR TITLE
Revert "update goreleaser from brews to homebrew_casks (#168)"

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -78,7 +78,7 @@ checksum:
   # Disable the generation/upload of the checksum file.
   disable: false
 
-homebrew_casks:
+brews:
   - # Git author used to commit to the repository.
     commit_author:
       name: "goreleaserbot"
@@ -87,10 +87,10 @@ homebrew_casks:
     # The project name and current git tag are used in the format string.
     #
     # Templates: allowed.
-    commit_msg_template: "Brew cask update for {{ .ProjectName }} version {{ .Tag }}"
+    commit_msg_template: "Brew formula update for {{ .ProjectName }} version {{ .Tag }}"
 
-    binaries:
-      - "pingcli"
+    # Directory inside the repository to put the formula.
+    directory: "Formula"
 
     # Caveats for the user of your binary.
     # caveats: "How to use this binary"
@@ -106,8 +106,13 @@ homebrew_casks:
     # Default: inferred from global metadata.
     description: "The Ping CLI is a unified command line interface for configuring and managing Ping Identity Services."
 
+    # SPDX identifier of your app's license.
+    #
+    # Default: inferred from global metadata.
+    license: "Apache License 2.0"
+
     # Setting this will prevent goreleaser to actually try to commit the updated
-    # cask - instead, the cask file will be stored on the dist directory
+    # formula - instead, the formula file will be stored on the dist directory
     # only, leaving the responsibility of publishing it to the user.
     # If set to auto, the release will not be uploaded to the homebrew tap
     # in case there is an indicator for prerelease in the tag e.g. v1.0.0-rc1
@@ -115,7 +120,7 @@ homebrew_casks:
     # Templates: allowed.
     skip_upload: "auto"
 
-    # So you can `brew test` your cask.
+    # So you can `brew test` your formula.
     #
     # Template: allowed
     # test: |

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Use PingIdentity's Homebrew tap to install Ping CLI
 
 ``` shell
 brew tap pingidentity/tap
-brew install --cask pingcli
+brew install pingcli
 ```
 
 #### Manual Installation
@@ -80,7 +80,7 @@ Use PingIdentity's Homebrew tap to install Ping CLI
 
 ``` shell
 brew tap pingidentity/tap
-brew install --cask pingcli
+brew install pingcli
 ```
 
 ##### Alpine (.apk)


### PR DESCRIPTION
This reverts commit 64bcab1f12f4facd04a88df31087009d0b289894.

The brew cask changes will need to coincide with an actual release.